### PR TITLE
[FIX] buildout syntax to override dependencies is '+=' instead of '='

### DIFF
--- a/buildout.dev.cfg
+++ b/buildout.dev.cfg
@@ -11,4 +11,4 @@ options.db_name=db
 options.data_dir=.filestore
 with_devtools = true
 
-eggs = pyinotify
+eggs += pyinotify


### PR DESCRIPTION
Thanks to @bealdav that pointed it out. 

In the buildout doc : http://docs.anybox.fr/anybox.recipe.openerp/1.8.0/configuration.html#inheritance we see that to change options the syntax is '+=' and not '='. 

Otherwise it erases the config in the buildout.cfg
