### PR TITLE
[FIX] reportlab incompatibility with Pillow

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -17,6 +17,6 @@ eggs = nose
 openerp_scripts = nosetests=nosetests command-line-options=-d
 
 [versions]
-reportlab = 2.7
+reportlab = 3.3
 pydot = 1.0.28
 python-dateutil = 2.4.0


### PR DESCRIPTION
use reportlab 3.3 (before 2.7)
